### PR TITLE
Properly log path in web proxy

### DIFF
--- a/lib/proxy-web.js
+++ b/lib/proxy-web.js
@@ -18,7 +18,7 @@ const run = ({port, target, config = {}}) => {
     ...config
   });
 
-  const web = (proxyRes, req) => {
+  webProxy.on('proxyRes', (proxyRes, req) => {
     if (proxyRes.statusCode === 500) {
       proxyRes.on('data', chunk => {
         log(`\n${chunk}\n`);
@@ -28,9 +28,7 @@ const run = ({port, target, config = {}}) => {
     const method = chalk.bold(req.method);
     const path = req.url.replace(/^\//, '');
     log(`${status} [${method}] ${target}${path ? `/${path}` : ''}`);
-  };
-
-  webProxy.on('proxyRes', web);
+  });
   webProxy.on('econnreset', (_, req, res) => {
     log('Connection closed');
     req.destroy();

--- a/lib/proxy-web.js
+++ b/lib/proxy-web.js
@@ -26,7 +26,8 @@ const run = ({port, target, config = {}}) => {
     }
     const status = paintStatus(proxyRes.statusCode);
     const method = chalk.bold(req.method);
-    log(`${status} [${method}] ${target}${req.url.replace(/^\//, '')}`);
+    const path = req.url.replace(/^\//, '');
+    log(`${status} [${method}] ${target}${path ? `/${path}` : ''}`);
   };
 
   webProxy.on('proxyRes', web);


### PR DESCRIPTION
This PR:

- Fixes the logging on the path (to close #8)
- Moves the `proxyRes` event handler inline so that intellisense of the callback arguments can be properly inferred