### PR TITLE
Remove query strings from URLs when searching for files

### DIFF
--- a/lib/proxy-files.js
+++ b/lib/proxy-files.js
@@ -23,6 +23,8 @@ const mime = {
   js: 'application/javascript'
 };
 
+const stripQueryStringFromURL = url => url.replace(/(.+?\/.+)\?.+$/g, '$1');
+
 const run = ({port, directory, fileExt = 'json', keepExtensions = true, slowMode = false}) => {
   const invoke = slowMode ? withTimer : immediately;
   const filesProxy = http.createServer();
@@ -34,11 +36,15 @@ const run = ({port, directory, fileExt = 'json', keepExtensions = true, slowMode
       return;
     }
 
-    const urlFile = req.url.split('/').splice(-1).pop() || `index.${fileExt}`;
+    const strippedURL = stripQueryStringFromURL(req.url);
+    const urlFile = strippedURL.split('/').splice(-1).pop() || `index.${fileExt}`;
     const urlFileExt = urlFile.indexOf('.') > -1 ? urlFile.split('.').splice(-1).pop() : null;
     const urlFileName = urlFile.split(`.${urlFileExt}`)[0];
+    log(`urlFile=${urlFile} urlFileExt=${urlFileExt} urlFileName=${urlFileName}`);
 
-    const url = replaceLast(urlFile, '', req.url);
+    const url = replaceLast(urlFile, '', strippedURL);
+    log(`url after replaceLast: ${url}`);
+
     const method = req.method;
 
     const finalFileExtension = keepExtensions && urlFileExt ? urlFileExt : fileExt;


### PR DESCRIPTION
We have a project that has begun using hashes in the query string to break through image caches, but the `warp-proxy` doesn't know how to parse them.